### PR TITLE
feat: 新增组件 AMapPolygonEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ npm install @amap/amap-jsapi-types
 https://cdn.jsdelivr.net/npm/amap-react-components@0.0.1/dist/amap-react-components.browser.js
 ```
 
+### Polyfill
+
+使用者可能需要自行处理以下兼容性
+
+- [Proxy](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
+  --> [Proxy Polyfill](https://github.com/GoogleChrome/proxy-polyfill)
+
 ## 其它
 
 - [@amap/amap-react](https://www.npmjs.com/package/@amap/amap-react) （高德官方 react 组件 ）

--- a/src/components/AMapPolygonEditor/AMapPolygonEditor.tsx
+++ b/src/components/AMapPolygonEditor/AMapPolygonEditor.tsx
@@ -1,0 +1,156 @@
+import type { FC } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  // useState,
+} from 'react';
+
+import useAMap from '../../hooks/useAMap';
+import useAMapPluginInstance from '../../hooks/useAMapPluginInstance';
+
+import type { AMapPolygonEditorProps } from './interface.d';
+
+const isPolygonFeature = (feature: any) => feature.className === 'Overlay.Polygon';
+
+const AMapPolygonEditor: FC<AMapPolygonEditorProps> = ({
+  computeTarget,
+  disabled,
+  computeAdsorbPolygons,
+  onChange,
+}) => {
+  const $lastOnChange = useRef<AMapPolygonEditorProps['onChange']>(onChange);
+  $lastOnChange.current = onChange;
+
+  const initInstance = useCallback((AMap, map) => new AMap!.PolygonEditor(map), []);
+  const curInstance = useAMapPluginInstance<AMap.PolygonEditor>('PolygonEditor', initInstance);
+  const { map } = useAMap();
+
+  const reSetTarget = useCallback(() => {
+    if (!curInstance) return;
+    const allPolygons: AMap.Polygon[] = map?.getAllOverlays('polygon') || [];
+    const newTarget = computeTarget(allPolygons) ?? null;
+    curInstance.setTarget(newTarget);
+  }, [map, computeTarget, curInstance]);
+
+  // 获取重新计算 target 然后更新
+  // computeTarget 更新 => reSetTarget 更新
+  // 更新后重新计算并执行
+  useEffect(() => {
+    if (!map) return;
+    reSetTarget();
+  }, [map, reSetTarget]);
+
+  // 监听地图中 overlays 的增加和减少
+  // 重新基于 computeTarget 计算 target
+  useEffect(() => {
+    let clearEffect;
+    if (!map) return clearEffect;
+
+    const handleOverlayChanged = (features: any[]) => {
+      if (isPolygonFeature(features) || (
+        Array.isArray(features)
+        && features.some(isPolygonFeature)
+      )) {
+        reSetTarget();
+      }
+    };
+
+    clearEffect = () => {
+      map.off('overlaysRemoved' as AMap.EventType, handleOverlayChanged);
+      map.off('overlaysAdded' as AMap.EventType, handleOverlayChanged);
+    };
+    map.on('overlaysRemoved' as AMap.EventType, handleOverlayChanged);
+    map.on('overlaysAdded' as AMap.EventType, handleOverlayChanged);
+
+    return clearEffect;
+  }, [map, reSetTarget]);
+
+  const reSetAdsorbPolygons = useCallback(() => {
+    if (!curInstance) return;
+    const allPolygons: AMap.Polygon[] = map?.getAllOverlays('polygon') || [];
+    const adsorbPolygons = computeAdsorbPolygons?.(allPolygons) || [];
+    if (adsorbPolygons) {
+      curInstance.setAdsorbPolygons(adsorbPolygons);
+    } else {
+      curInstance.clearAdsorbPolygons();
+    }
+  }, [map, computeAdsorbPolygons, curInstance]);
+
+  // 获取重新计算 adsorbPolygons 然后更新
+  // computeAdsorbPolygons 更新 => reSetAdsorbPolygons 更新
+  // 更新后重新计算并执行
+  useEffect(() => {
+    if (!map) return;
+    reSetAdsorbPolygons();
+  }, [map, reSetAdsorbPolygons]);
+
+  // 监听地图中 overlays 的增加和减少
+  // 重新基于 computeTarget 计算 target
+  useEffect(() => {
+    let clearEffect;
+    if (!map) return clearEffect;
+
+    const handleOverlayChanged = (features: any[]) => {
+      if (isPolygonFeature(features) || (
+        Array.isArray(features)
+        && features.some(isPolygonFeature)
+      )) {
+        reSetAdsorbPolygons();
+      }
+    };
+
+    clearEffect = () => {
+      map.off('overlaysRemoved' as AMap.EventType, handleOverlayChanged);
+      map.off('overlaysAdded' as AMap.EventType, handleOverlayChanged);
+    };
+    map.on('overlaysRemoved' as AMap.EventType, handleOverlayChanged);
+    map.on('overlaysAdded' as AMap.EventType, handleOverlayChanged);
+
+    return clearEffect;
+  }, [map, reSetAdsorbPolygons]);
+
+  // 监听变化，触发 onChange 通知
+  useEffect(() => {
+    let clearEffect;
+    if (!curInstance) return clearEffect;
+
+    const triggerChangeHandler = (obj: any) => {
+      $lastOnChange.current?.(obj);
+    };
+
+    clearEffect = () => {
+      curInstance?.off('add', triggerChangeHandler);
+      curInstance?.off('addnode', triggerChangeHandler);
+      curInstance?.off('adjust', triggerChangeHandler);
+      curInstance?.off('removenode', triggerChangeHandler);
+    };
+
+    curInstance.on('add', triggerChangeHandler);
+    curInstance.on('addnode', triggerChangeHandler);
+    curInstance.on('adjust', triggerChangeHandler);
+    curInstance.on('removenode', triggerChangeHandler);
+
+    return clearEffect;
+  }, [curInstance]);
+
+  // 是否打开
+  useEffect(() => {
+    if (disabled) {
+      curInstance?.close();
+    } else {
+      curInstance?.open();
+    }
+  }, [curInstance, disabled]);
+
+  return null;
+};
+
+AMapPolygonEditor.defaultProps = {
+  // eslint-disable-next-line react/default-props-match-prop-types
+  disabled: false,
+  // eslint-disable-next-line react/default-props-match-prop-types
+  computeAdsorbPolygons: (allPolygons) => allPolygons,
+};
+
+export default AMapPolygonEditor;

--- a/src/components/AMapPolygonEditor/index.ts
+++ b/src/components/AMapPolygonEditor/index.ts
@@ -1,0 +1,2 @@
+export type { AMapPolygonEditorProps } from './interface.d';
+export { default } from './AMapPolygonEditor';

--- a/src/components/AMapPolygonEditor/interface.d.ts
+++ b/src/components/AMapPolygonEditor/interface.d.ts
@@ -1,0 +1,7 @@
+export type AMapPolygonEditorProps = {
+  computeTarget(allPolygons: AMap.Polygon[]): AMap.Polygon | null | undefined;
+  disabled?: boolean;
+  //
+  computeAdsorbPolygons?(allPolygons: AMap.Polygon[]): AMap.Polygon[] | null | undefined;
+  onChange?: (obj: any) => void;
+};

--- a/src/components/AMapPolygonEditor/stories/AMapPolygonEditor.stories.tsx
+++ b/src/components/AMapPolygonEditor/stories/AMapPolygonEditor.stories.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+
+import type { AMapPolygonEditorProps } from 'index';
+import { AMapGeoJSON, AMapPolygonEditor } from 'index';
+import { actions } from '@storybook/addon-actions';
+import { withAMapContainer } from '../../AMapMap/stories/AMapMap.stories';
+import withAutoFitView from '../../AMapAutoFitView/stories/withAutoFitView';
+
+const eventHandler = actions(
+  'onChange',
+);
+
+const commonPolygon: GeoJSON.Polygon = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [116.386069, 39.898857],
+      [116.386023, 39.897477],
+      [116.387719, 39.897539],
+      [116.386069, 39.898857],
+    ],
+  ],
+};
+
+const polygonWithHole: GeoJSON.Polygon = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [116.384595, 39.901321],
+      [116.383526, 39.899865],
+      [116.386284, 39.900917],
+      [116.384595, 39.901321],
+    ],
+    [
+      [116.384594, 39.901],
+      [116.384, 39.9003],
+      [116.3861, 39.900917],
+      [116.384594, 39.901],
+    ],
+  ],
+};
+const multiPolygon: GeoJSON.MultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [116.388624, 39.900055],
+        [116.390452, 39.898583],
+        [116.391294, 39.900003],
+        [116.388624, 39.900055],
+      ],
+      [
+        [116.389113, 39.899924],
+        [116.390251, 39.898962],
+        [116.391055, 39.899899],
+        [116.389113, 39.899924],
+      ],
+    ],
+    [
+      [
+        [116.387884, 39.899645],
+        [116.38796, 39.898347],
+        [116.390175, 39.898394],
+        [116.387884, 39.899645],
+      ],
+    ],
+  ],
+};
+
+const mockData: GeoJSON.FeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: commonPolygon,
+      properties: {},
+    },
+    {
+      type: 'Feature',
+      geometry: polygonWithHole,
+      properties: {},
+    },
+    {
+      type: 'Feature',
+      geometry: multiPolygon,
+      properties: {},
+    },
+  ],
+};
+
+export default {
+  title: '组件(Components)/工具(Tools)/AMapPolygonEditor',
+  decorators: [withAutoFitView, withAMapContainer],
+  args: {
+    computeTarget: (polygons: Parameters<AMapPolygonEditorProps['computeTarget']>[0]) => polygons[0],
+    onChange: eventHandler.onChange,
+  },
+  argTypes: {
+    computeTarget: {
+      description: '设置编辑对象',
+      type: { required: true, summary: '(allPolygons: AMap.Polygon[]): AMap.Polygon[] | null | undefined' },
+      control: false,
+    },
+    disabled: {
+      description: '禁用 PolygonEditor',
+      type: { required: false, summary: 'boolean', defaultValue: true },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+      control: {
+        type: 'boolean',
+      },
+    },
+    computeAdsorbPolygons: {
+      description: '设置吸附多边形。默认地图上所有多边形都可吸附',
+      type: { required: false, summary: '(allPolygons: AMap.Polygon[]): AMap.Polygon[] | null | undefined' },
+      table: {
+        defaultValue: {
+          summary: '(allPolygons: AMap.Polygon[]) => allPolygons',
+        },
+      },
+      control: false,
+    },
+    onChange: {
+      description: 'Target 变化时的回调',
+      type: { required: false, summary: '(event: any) => void' },
+      control: false,
+    },
+  },
+} as Meta;
+
+const Template: Story<AMapPolygonEditorProps> = (args) => (
+  <>
+    <AMapGeoJSON geoJSON={mockData} />
+    <AMapPolygonEditor {...args} />
+  </>
+);
+
+export const WithGeoJSON: typeof Template = Template.bind({});
+WithGeoJSON.storyName = '与AMapGeoJSON一同使用';
+WithGeoJSON.args = {
+  computeTarget: (polygons) => polygons[1],
+};
+
+export const SetAdsorbPolygons: typeof Template = Template.bind({});
+SetAdsorbPolygons.storyName = '自定义磁吸围栏';
+SetAdsorbPolygons.args = {
+  computeAdsorbPolygons: (polygons) => polygons.filter((_, index) => index === 1),
+};
+
+export const DisablePolygonEditor: typeof Template = Template.bind({});
+DisablePolygonEditor.storyName = '禁用编辑器';
+DisablePolygonEditor.args = {
+  disabled: true,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export {
 export { default as AMapCircle, AMapCircleProps } from './components/AMapCircle';
 export { default as AMapEllipse, AMapEllipseProps } from './components/AMapEllipse';
 export { default as AMapMarker, AMapMarkerProps } from './components/AMapMarker';
+export {
+  default as AMapPolygonEditor,
+  AMapPolygonEditorProps,
+} from './components/AMapPolygonEditor';
 
 export { default as AMapMouseTool, AMapMouseToolProps } from './components/AMapMouseTool';
 


### PR DESCRIPTION
基于 [Proxy](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Proxy) 创建 map 实例的代理
`map.add`/`map.remove` 会分别触发 `overlaysAdded`/`overlaysRemoved` 事件

Breaking 使用者需要处理 Proxy 的兼容性